### PR TITLE
feat: Sprint 2.1 - 会员管理功能 (MemberController)

### DIFF
--- a/internal/contracts/member.go
+++ b/internal/contracts/member.go
@@ -1,0 +1,82 @@
+package contracts
+
+import "time"
+
+// Member contracts 会员管理相关的API契约
+
+// UpdateMemberRequest 更新会员信息请求
+type UpdateMemberRequest struct {
+	ID       string `json:"id,omitempty"` // 会员ID (从JWT获取，请求中不需要)
+	Nickname string `json:"nickname" binding:"required" validate:"min=2,max=50" example:"张三"`
+	Avatar   string `json:"avatar" binding:"required" validate:"url" example:"https://example.com/avatar.jpg"`
+}
+
+// UpdateMemberResponse 更新会员信息响应
+type UpdateMemberResponse struct {
+	ID       string `json:"id" example:"member-123"`
+	Nickname string `json:"nickname" example:"张三"`
+	Avatar   string `json:"avatar" example:"https://example.com/avatar.jpg"`
+	Success  bool   `json:"success" example:"true"`
+}
+
+// CreateFranchiseIntentionRequest 创建加盟意向请求
+type CreateFranchiseIntentionRequest struct {
+	MemberID         string `json:"memberId,omitempty"` // 会员ID (从JWT获取)
+	ContactName      string `json:"contactName" binding:"required" validate:"min=2,max=50" example:"张三"`
+	ContactPhone     string `json:"contactPhone" binding:"required" validate:"phone" example:"13800138000"`
+	IntendedLocation string `json:"intendedLocation" binding:"required" validate:"min=5,max=200" example:"北京市朝阳区建国门外大街"`
+	Remarks          string `json:"remarks,omitempty" validate:"max=500" example:"希望能在繁华地段开店"`
+}
+
+// CreateFranchiseIntentionResponse 创建加盟意向响应
+type CreateFranchiseIntentionResponse struct {
+	ID               string    `json:"id" example:"intention-123"`
+	MemberID         string    `json:"memberId" example:"member-123"`
+	ContactName      string    `json:"contactName" example:"张三"`
+	ContactPhone     string    `json:"contactPhone" example:"13800138000"`
+	IntendedLocation string    `json:"intendedLocation" example:"北京市朝阳区建国门外大街"`
+	Status           string    `json:"status" example:"Pending"`
+	CreatedAt        time.Time `json:"createdAt" example:"2023-01-01T00:00:00Z"`
+	Success          bool      `json:"success" example:"true"`
+}
+
+// FranchiseIntentionStatus 加盟意向状态枚举
+type FranchiseIntentionStatus string
+
+const (
+	FranchiseIntentionStatusPending  FranchiseIntentionStatus = "Pending"  // 待处理
+	FranchiseIntentionStatusApproved FranchiseIntentionStatus = "Approved" // 已批准
+	FranchiseIntentionStatusRejected FranchiseIntentionStatus = "Rejected" // 已拒绝
+)
+
+// GetMemberInfoResponse 获取会员信息响应
+type GetMemberInfoResponse struct {
+	ID                  string                      `json:"id" example:"member-123"`
+	Nickname            string                      `json:"nickname" example:"张三"`
+	Avatar              string                      `json:"avatar" example:"https://example.com/avatar.jpg"`
+	WeChatOpenID        string                      `json:"weChatOpenId" example:"wx_openid_123"`
+	Role                string                      `json:"role" example:"Member"`
+	MachineOwnerID      string                      `json:"machineOwnerId,omitempty" example:"owner-123"`
+	IsAdmin             bool                        `json:"isAdmin" example:"false"`
+	CreatedAt           time.Time                   `json:"createdAt" example:"2023-01-01T00:00:00Z"`
+	UpdatedAt           time.Time                   `json:"updatedAt" example:"2023-01-01T00:00:00Z"`
+	FranchiseIntentions []FranchiseIntentionSummary `json:"franchiseIntentions,omitempty"`
+}
+
+// FranchiseIntentionSummary 加盟意向摘要
+type FranchiseIntentionSummary struct {
+	ID               string                   `json:"id" example:"intention-123"`
+	ContactName      string                   `json:"contactName" example:"张三"`
+	IntendedLocation string                   `json:"intendedLocation" example:"北京市朝阳区"`
+	Status           FranchiseIntentionStatus `json:"status" example:"Pending"`
+	CreatedAt        time.Time                `json:"createdAt" example:"2023-01-01T00:00:00Z"`
+}
+
+// Member相关的错误码
+const (
+	ErrorCodeMemberNotFound      = "MEMBER_NOT_FOUND"
+	ErrorCodeMemberUpdateFailed  = "MEMBER_UPDATE_FAILED"
+	ErrorCodeFranchiseExists     = "FRANCHISE_INTENTION_EXISTS"
+	ErrorCodeFranchiseCreateFail = "FRANCHISE_CREATE_FAILED"
+	ErrorCodeInvalidMemberData   = "INVALID_MEMBER_DATA"
+)

--- a/internal/contracts/member_test.go
+++ b/internal/contracts/member_test.go
@@ -1,0 +1,117 @@
+package contracts
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUpdateMemberRequest(t *testing.T) {
+	req := UpdateMemberRequest{
+		ID:       "member-123",
+		Nickname: "张三",
+		Avatar:   "https://example.com/avatar.jpg",
+	}
+
+	if req.ID != "member-123" {
+		t.Errorf("expected ID to be 'member-123', got '%s'", req.ID)
+	}
+
+	if req.Nickname != "张三" {
+		t.Errorf("expected Nickname to be '张三', got '%s'", req.Nickname)
+	}
+
+	if req.Avatar != "https://example.com/avatar.jpg" {
+		t.Errorf("expected Avatar to be 'https://example.com/avatar.jpg', got '%s'", req.Avatar)
+	}
+}
+
+func TestCreateFranchiseIntentionRequest(t *testing.T) {
+	req := CreateFranchiseIntentionRequest{
+		MemberID:         "member-123",
+		ContactName:      "张三",
+		ContactPhone:     "13800138000",
+		IntendedLocation: "北京市朝阳区",
+		Remarks:          "希望在繁华地段开店",
+	}
+
+	if req.MemberID != "member-123" {
+		t.Errorf("expected MemberID to be 'member-123', got '%s'", req.MemberID)
+	}
+
+	if req.ContactName != "张三" {
+		t.Errorf("expected ContactName to be '张三', got '%s'", req.ContactName)
+	}
+}
+
+func TestFranchiseIntentionStatus(t *testing.T) {
+	testCases := []struct {
+		status   FranchiseIntentionStatus
+		expected string
+	}{
+		{FranchiseIntentionStatusPending, "Pending"},
+		{FranchiseIntentionStatusApproved, "Approved"},
+		{FranchiseIntentionStatusRejected, "Rejected"},
+	}
+
+	for _, tc := range testCases {
+		if string(tc.status) != tc.expected {
+			t.Errorf("expected status '%s', got '%s'", tc.expected, string(tc.status))
+		}
+	}
+}
+
+func TestGetMemberInfoResponse(t *testing.T) {
+	now := time.Now()
+	intentions := []FranchiseIntentionSummary{
+		{
+			ID:               "fi-123",
+			ContactName:      "张三",
+			IntendedLocation: "北京市",
+			Status:           FranchiseIntentionStatusPending,
+			CreatedAt:        now,
+		},
+	}
+
+	response := GetMemberInfoResponse{
+		ID:                  "member-123",
+		Nickname:            "张三",
+		Avatar:              "https://example.com/avatar.jpg",
+		WeChatOpenID:        "wx_openid_123",
+		Role:                "Member",
+		IsAdmin:             false,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+		FranchiseIntentions: intentions,
+	}
+
+	if response.ID != "member-123" {
+		t.Errorf("expected ID to be 'member-123', got '%s'", response.ID)
+	}
+
+	if len(response.FranchiseIntentions) != 1 {
+		t.Errorf("expected 1 franchise intention, got %d", len(response.FranchiseIntentions))
+	}
+
+	if response.FranchiseIntentions[0].Status != FranchiseIntentionStatusPending {
+		t.Errorf("expected status to be 'Pending', got '%s'", string(response.FranchiseIntentions[0].Status))
+	}
+}
+
+func TestMemberErrorCodes(t *testing.T) {
+	testCases := []struct {
+		code     string
+		expected string
+	}{
+		{ErrorCodeMemberNotFound, "MEMBER_NOT_FOUND"},
+		{ErrorCodeMemberUpdateFailed, "MEMBER_UPDATE_FAILED"},
+		{ErrorCodeFranchiseExists, "FRANCHISE_INTENTION_EXISTS"},
+		{ErrorCodeFranchiseCreateFail, "FRANCHISE_CREATE_FAILED"},
+		{ErrorCodeInvalidMemberData, "INVALID_MEMBER_DATA"},
+	}
+
+	for _, tc := range testCases {
+		if tc.code != tc.expected {
+			t.Errorf("expected error code '%s', got '%s'", tc.expected, tc.code)
+		}
+	}
+}

--- a/internal/handlers/member.go
+++ b/internal/handlers/member.go
@@ -1,6 +1,11 @@
 package handlers
 
 import (
+	"net/http"
+
+	"github.com/ddteam/drink-master/internal/contracts"
+	"github.com/ddteam/drink-master/internal/repositories"
+	"github.com/ddteam/drink-master/internal/services"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
@@ -8,12 +13,18 @@ import (
 // MemberHandler 会员处理器 (对应MobileAPI MemberController)
 type MemberHandler struct {
 	*BaseHandler
+	memberService *services.MemberService
 }
 
 // NewMemberHandler 创建会员处理器
 func NewMemberHandler(db *gorm.DB) *MemberHandler {
+	memberRepo := repositories.NewMemberRepository(db)
+	franchiseRepo := repositories.NewFranchiseIntentionRepository(db)
+	memberService := services.NewMemberService(memberRepo, franchiseRepo)
+
 	return &MemberHandler{
-		BaseHandler: NewBaseHandler(db),
+		BaseHandler:   NewBaseHandler(db),
+		memberService: memberService,
 	}
 }
 
@@ -26,10 +37,22 @@ func (h *MemberHandler) Update(c *gin.Context) {
 		return
 	}
 
-	// TODO: 实现会员信息更新逻辑
-	h.SuccessResponseWithMessage(c, map[string]interface{}{
-		"id": memberID,
-	}, "会员信息更新成功")
+	var req contracts.UpdateMemberRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.ValidationErrorResponse(c, err)
+		return
+	}
+
+	// 设置会员ID（从JWT获取）
+	req.ID = memberID
+
+	response, err := h.memberService.UpdateMember(memberID, req)
+	if err != nil {
+		h.InternalErrorResponse(c, err)
+		return
+	}
+
+	h.SuccessResponse(c, response)
 }
 
 // AddFranchiseIntention 添加加盟意向
@@ -41,8 +64,52 @@ func (h *MemberHandler) AddFranchiseIntention(c *gin.Context) {
 		return
 	}
 
-	// TODO: 实现加盟意向添加逻辑
-	h.SuccessResponseWithMessage(c, map[string]interface{}{
-		"memberId": memberID,
-	}, "加盟意向提交成功")
+	var req contracts.CreateFranchiseIntentionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.ValidationErrorResponse(c, err)
+		return
+	}
+
+	// 设置会员ID（从JWT获取）
+	req.MemberID = memberID
+
+	response, err := h.memberService.CreateFranchiseIntention(memberID, req)
+	if err != nil {
+		// 检查是否是业务逻辑错误
+		if err.Error() == "member already has pending franchise intention" {
+			c.JSON(http.StatusConflict, gin.H{
+				"error":   "已存在待处理的加盟意向",
+				"code":    contracts.ErrorCodeFranchiseExists,
+				"success": false,
+			})
+			return
+		}
+
+		h.InternalErrorResponse(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"data":    response,
+		"message": "加盟意向提交成功",
+		"success": true,
+	})
+}
+
+// GetUserInfo 获取用户信息（包含加盟意向）
+// GET /api/Member/GetUserInfo
+func (h *MemberHandler) GetUserInfo(c *gin.Context) {
+	memberID, exists := h.GetMemberID(c)
+	if !exists {
+		h.UnauthorizedResponse(c, "无效的用户信息")
+		return
+	}
+
+	response, err := h.memberService.GetMemberInfo(memberID)
+	if err != nil {
+		h.InternalErrorResponse(c, err)
+		return
+	}
+
+	h.SuccessResponse(c, response)
 }

--- a/internal/handlers/member_test.go
+++ b/internal/handlers/member_test.go
@@ -25,6 +25,7 @@ func setupMemberTestRouter() (*gin.Engine, *MemberHandler) {
 
 	router.POST("/api/Member/Update", memberHandler.Update)
 	router.POST("/api/Member/AddFranchiseIntention", memberHandler.AddFranchiseIntention)
+	router.GET("/api/Member/GetUserInfo", memberHandler.GetUserInfo)
 
 	return router, memberHandler
 }
@@ -64,17 +65,26 @@ func TestMemberHandler_Update_WithAuth(t *testing.T) {
 	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	handler := NewMemberHandler(db)
 
+	// 创建有效的JSON请求体
+	updateData := map[string]interface{}{
+		"nickname": "新用户名",
+		"avatar":   "https://example.com/avatar.jpg",
+	}
+	jsonData, _ := json.Marshal(updateData)
+
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request, _ = http.NewRequest("POST", "/api/Member/Update", nil)
+	c.Request, _ = http.NewRequest("POST", "/api/Member/Update", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
 
 	// 设置认证信息
 	c.Set("member_id", "test_member_123")
 
 	handler.Update(c)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	// 由于数据库中没有这个member，期望会返回500错误
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.Code)
 	}
 }
 
@@ -105,16 +115,62 @@ func TestMemberHandler_AddFranchiseIntention_WithAuth(t *testing.T) {
 	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	handler := NewMemberHandler(db)
 
+	// 创建有效的JSON请求体
+	intentionData := map[string]interface{}{
+		"contactName":      "张三",
+		"contactPhone":     "13800138000",
+		"intendedLocation": "北京市朝阳区",
+		"remarks":          "希望开设新店",
+	}
+	jsonData, _ := json.Marshal(intentionData)
+
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request, _ = http.NewRequest("POST", "/api/Member/AddFranchiseIntention", nil)
+	c.Request, _ = http.NewRequest("POST", "/api/Member/AddFranchiseIntention", bytes.NewBuffer(jsonData))
+	c.Request.Header.Set("Content-Type", "application/json")
 
 	// 设置认证信息
 	c.Set("member_id", "test_member_456")
 
 	handler.AddFranchiseIntention(c)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	// 由于数据库中没有这个member，期望会返回500错误
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+func TestMemberHandler_GetUserInfo(t *testing.T) {
+	router, _ := setupMemberTestRouter()
+
+	// 测试没有认证的情况
+	req, _ := http.NewRequest("GET", "/api/Member/GetUserInfo", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// 没有member_id会返回401
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+}
+
+func TestMemberHandler_GetUserInfo_WithAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	handler := NewMemberHandler(db)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("GET", "/api/Member/GetUserInfo", nil)
+
+	// 设置认证信息
+	c.Set("member_id", "test_member_789")
+
+	handler.GetUserInfo(c)
+
+	// 由于数据库中没有这个member，期望会返回500错误
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.Code)
 	}
 }

--- a/internal/models/franchise_intention.go
+++ b/internal/models/franchise_intention.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// FranchiseIntention 加盟意向模型
+type FranchiseIntention struct {
+	ID               string         `json:"id" gorm:"type:varchar(36);primaryKey;not null"`
+	MemberID         string         `json:"memberId" gorm:"type:varchar(36);not null;index"`
+	ContactName      string         `json:"contactName" gorm:"type:varchar(50);not null"`
+	ContactPhone     string         `json:"contactPhone" gorm:"type:varchar(20);not null"`
+	IntendedLocation string         `json:"intendedLocation" gorm:"type:text;not null"`
+	Remarks          string         `json:"remarks" gorm:"type:text"`
+	Status           string         `json:"status" gorm:"type:varchar(20);not null;default:'Pending'"`
+	CreatedAt        time.Time      `json:"createdAt" gorm:"autoCreateTime"`
+	UpdatedAt        time.Time      `json:"updatedAt" gorm:"autoUpdateTime"`
+	DeletedAt        gorm.DeletedAt `json:"-" gorm:"index"`
+
+	// 关联关系
+	Member Member `json:"member,omitempty" gorm:"foreignKey:MemberID;references:ID"`
+}
+
+// TableName 指定表名
+func (FranchiseIntention) TableName() string {
+	return "franchise_intentions"
+}
+
+// BeforeCreate GORM钩子，创建前验证
+func (fi *FranchiseIntention) BeforeCreate(tx *gorm.DB) error {
+	// ID需要在创建前由调用方设置
+	if fi.ID == "" {
+		return nil // 让GORM处理或在service层生成
+	}
+	return nil
+}
+
+// BeforeUpdate GORM钩子，更新前验证
+func (fi *FranchiseIntention) BeforeUpdate(tx *gorm.DB) error {
+	// 确保状态值有效
+	validStatuses := []string{"Pending", "Approved", "Rejected"}
+	statusValid := false
+	for _, status := range validStatuses {
+		if fi.Status == status {
+			statusValid = true
+			break
+		}
+	}
+	if !statusValid {
+		fi.Status = "Pending" // 默认状态
+	}
+	return nil
+}
+
+// IsApproved 检查加盟意向是否已被批准
+func (fi *FranchiseIntention) IsApproved() bool {
+	return fi.Status == "Approved"
+}
+
+// IsRejected 检查加盟意向是否已被拒绝
+func (fi *FranchiseIntention) IsRejected() bool {
+	return fi.Status == "Rejected"
+}
+
+// IsPending 检查加盟意向是否待处理
+func (fi *FranchiseIntention) IsPending() bool {
+	return fi.Status == "Pending"
+}

--- a/internal/models/franchise_intention_test.go
+++ b/internal/models/franchise_intention_test.go
@@ -1,0 +1,110 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestFranchiseIntention_TableName(t *testing.T) {
+	fi := FranchiseIntention{}
+	expected := "franchise_intentions"
+
+	if fi.TableName() != expected {
+		t.Errorf("Expected table name %s, got %s", expected, fi.TableName())
+	}
+}
+
+func TestFranchiseIntention_BeforeCreate(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to test database: %v", err)
+	}
+
+	// 自动迁移
+	err = AutoMigrate(db)
+	if err != nil {
+		t.Fatalf("Failed to migrate: %v", err)
+	}
+
+	fi := &FranchiseIntention{
+		ID:               "test-id",
+		MemberID:         "member-123",
+		ContactName:      "张三",
+		ContactPhone:     "13800138000",
+		IntendedLocation: "北京市",
+		Status:           "Pending",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	// 测试BeforeCreate钩子
+	err = fi.BeforeCreate(db)
+	if err != nil {
+		t.Errorf("BeforeCreate should not return error: %v", err)
+	}
+}
+
+func TestFranchiseIntention_BeforeUpdate(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to test database: %v", err)
+	}
+
+	fi := &FranchiseIntention{
+		Status: "InvalidStatus",
+	}
+
+	// 测试BeforeUpdate钩子 - 无效状态会被重置为Pending
+	err = fi.BeforeUpdate(db)
+	if err != nil {
+		t.Errorf("BeforeUpdate should not return error: %v", err)
+	}
+
+	if fi.Status != "Pending" {
+		t.Errorf("Expected status to be reset to 'Pending', got %s", fi.Status)
+	}
+
+	// 测试有效状态
+	fi.Status = "Approved"
+	err = fi.BeforeUpdate(db)
+	if err != nil {
+		t.Errorf("BeforeUpdate should not return error: %v", err)
+	}
+
+	if fi.Status != "Approved" {
+		t.Errorf("Expected status to remain 'Approved', got %s", fi.Status)
+	}
+}
+
+func TestFranchiseIntention_StatusMethods(t *testing.T) {
+	testCases := []struct {
+		status     string
+		isPending  bool
+		isApproved bool
+		isRejected bool
+	}{
+		{"Pending", true, false, false},
+		{"Approved", false, true, false},
+		{"Rejected", false, false, true},
+		{"Unknown", false, false, false},
+	}
+
+	for _, tc := range testCases {
+		fi := FranchiseIntention{Status: tc.status}
+
+		if fi.IsPending() != tc.isPending {
+			t.Errorf("Status %s: expected IsPending %v, got %v", tc.status, tc.isPending, fi.IsPending())
+		}
+
+		if fi.IsApproved() != tc.isApproved {
+			t.Errorf("Status %s: expected IsApproved %v, got %v", tc.status, tc.isApproved, fi.IsApproved())
+		}
+
+		if fi.IsRejected() != tc.isRejected {
+			t.Errorf("Status %s: expected IsRejected %v, got %v", tc.status, tc.isRejected, fi.IsRejected())
+		}
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -13,6 +13,7 @@ func AutoMigrate(db *gorm.DB) error {
 		&Product{},
 		&MachineProductPrice{},
 		&Order{},
+		&FranchiseIntention{},
 	)
 }
 
@@ -25,5 +26,6 @@ func AllModels() []interface{} {
 		&Product{},
 		&MachineProductPrice{},
 		&Order{},
+		&FranchiseIntention{},
 	}
 }

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -22,7 +22,7 @@ func TestAutoMigrate(t *testing.T) {
 	}
 
 	// 验证表是否被创建
-	tables := []string{"members", "machine_owners", "machines", "products", "machine_product_prices", "orders"}
+	tables := []string{"members", "machine_owners", "machines", "products", "machine_product_prices", "orders", "franchise_intentions"}
 
 	for _, table := range tables {
 		if !db.Migrator().HasTable(table) {
@@ -39,7 +39,7 @@ func TestAllModels(t *testing.T) {
 	}
 
 	// 验证返回的模型数量
-	expectedCount := 6 // Member, MachineOwner, Machine, Product, MachineProductPrice, Order
+	expectedCount := 7 // Member, MachineOwner, Machine, Product, MachineProductPrice, Order, FranchiseIntention
 	if len(models) != expectedCount {
 		t.Errorf("Expected %d models, got %d", expectedCount, len(models))
 	}

--- a/internal/repositories/franchise_intention_repository.go
+++ b/internal/repositories/franchise_intention_repository.go
@@ -1,0 +1,126 @@
+package repositories
+
+import (
+	"fmt"
+
+	"github.com/ddteam/drink-master/internal/models"
+	"gorm.io/gorm"
+)
+
+// FranchiseIntentionRepository 加盟意向数据访问层
+type FranchiseIntentionRepository struct {
+	db *gorm.DB
+}
+
+// NewFranchiseIntentionRepository 创建加盟意向Repository实例
+func NewFranchiseIntentionRepository(db *gorm.DB) *FranchiseIntentionRepository {
+	return &FranchiseIntentionRepository{db: db}
+}
+
+// Create 创建加盟意向
+func (r *FranchiseIntentionRepository) Create(intention *models.FranchiseIntention) error {
+	err := r.db.Create(intention).Error
+	if err != nil {
+		return fmt.Errorf("failed to create franchise intention: %w", err)
+	}
+	return nil
+}
+
+// GetByID 根据ID获取加盟意向
+func (r *FranchiseIntentionRepository) GetByID(id string) (*models.FranchiseIntention, error) {
+	var intention models.FranchiseIntention
+	err := r.db.Where("id = ? AND deleted_at IS NULL", id).
+		Preload("Member").
+		First(&intention).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("franchise intention not found: %s", id)
+		}
+		return nil, fmt.Errorf("failed to get franchise intention: %w", err)
+	}
+	return &intention, nil
+}
+
+// GetByMemberID 根据会员ID获取加盟意向列表
+func (r *FranchiseIntentionRepository) GetByMemberID(memberID string) ([]models.FranchiseIntention, error) {
+	var intentions []models.FranchiseIntention
+	err := r.db.Where("member_id = ? AND deleted_at IS NULL", memberID).
+		Order("created_at DESC").
+		Find(&intentions).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get franchise intentions for member %s: %w", memberID, err)
+	}
+	return intentions, nil
+}
+
+// CheckExistingByMember 检查会员是否已有待处理的加盟意向
+func (r *FranchiseIntentionRepository) CheckExistingByMember(memberID string) (bool, error) {
+	var count int64
+	err := r.db.Model(&models.FranchiseIntention{}).
+		Where("member_id = ? AND status = ? AND deleted_at IS NULL", memberID, "Pending").
+		Count(&count).Error
+	if err != nil {
+		return false, fmt.Errorf("failed to check existing franchise intention: %w", err)
+	}
+	return count > 0, nil
+}
+
+// Update 更新加盟意向
+func (r *FranchiseIntentionRepository) Update(intention *models.FranchiseIntention) error {
+	err := r.db.Save(intention).Error
+	if err != nil {
+		return fmt.Errorf("failed to update franchise intention: %w", err)
+	}
+	return nil
+}
+
+// UpdateStatus 更新加盟意向状态
+func (r *FranchiseIntentionRepository) UpdateStatus(id string, status string) error {
+	err := r.db.Model(&models.FranchiseIntention{}).
+		Where("id = ? AND deleted_at IS NULL", id).
+		Update("status", status).Error
+	if err != nil {
+		return fmt.Errorf("failed to update franchise intention status: %w", err)
+	}
+	return nil
+}
+
+// Delete 软删除加盟意向
+func (r *FranchiseIntentionRepository) Delete(id string) error {
+	err := r.db.Where("id = ?", id).Delete(&models.FranchiseIntention{}).Error
+	if err != nil {
+		return fmt.Errorf("failed to delete franchise intention: %w", err)
+	}
+	return nil
+}
+
+// GetPaginated 分页获取加盟意向列表
+func (r *FranchiseIntentionRepository) GetPaginated(
+	offset, limit int, status string,
+) ([]models.FranchiseIntention, int64, error) {
+	var intentions []models.FranchiseIntention
+	var total int64
+
+	query := r.db.Model(&models.FranchiseIntention{}).Where("deleted_at IS NULL")
+	if status != "" {
+		query = query.Where("status = ?", status)
+	}
+
+	// 获取总数
+	err := query.Count(&total).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count franchise intentions: %w", err)
+	}
+
+	// 获取分页数据
+	err = query.Preload("Member").
+		Order("created_at DESC").
+		Offset(offset).
+		Limit(limit).
+		Find(&intentions).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get paginated franchise intentions: %w", err)
+	}
+
+	return intentions, total, nil
+}

--- a/internal/repositories/franchise_intention_repository_test.go
+++ b/internal/repositories/franchise_intention_repository_test.go
@@ -1,0 +1,263 @@
+package repositories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ddteam/drink-master/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupFranchiseTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	err = models.AutoMigrate(db)
+	if err != nil {
+		t.Fatalf("failed to migrate database: %v", err)
+	}
+
+	return db
+}
+
+func createTestFranchiseIntention(t *testing.T, db *gorm.DB, memberID string) *models.FranchiseIntention {
+	intention := &models.FranchiseIntention{
+		ID:               "test-franchise-1",
+		MemberID:         memberID,
+		ContactName:      "张三",
+		ContactPhone:     "13800138000",
+		IntendedLocation: "北京市朝阳区",
+		Status:           "Pending",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	err := db.Create(intention).Error
+	if err != nil {
+		t.Fatalf("failed to create test franchise intention: %v", err)
+	}
+
+	return intention
+}
+
+func TestNewFranchiseIntentionRepository(t *testing.T) {
+	db := setupFranchiseTestDB(t)
+	repo := NewFranchiseIntentionRepository(db)
+
+	if repo == nil {
+		t.Fatal("expected repository to be created")
+	}
+
+	if repo.db != db {
+		t.Error("expected repository to have correct database connection")
+	}
+}
+
+func TestFranchiseIntentionRepository_Create(t *testing.T) {
+	db := setupFranchiseTestDB(t)
+	repo := NewFranchiseIntentionRepository(db)
+
+	intention := &models.FranchiseIntention{
+		ID:               "test-create-1",
+		MemberID:         "member-123",
+		ContactName:      "李四",
+		ContactPhone:     "13900139000",
+		IntendedLocation: "上海市",
+		Status:           "Pending",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	err := repo.Create(intention)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// 验证创建
+	var found models.FranchiseIntention
+	err = db.Where("id = ?", intention.ID).First(&found).Error
+	if err != nil {
+		t.Fatalf("expected to find created intention, got error: %v", err)
+	}
+
+	if found.ContactName != intention.ContactName {
+		t.Errorf("expected contact name '%s', got '%s'", intention.ContactName, found.ContactName)
+	}
+}
+
+func TestFranchiseIntentionRepository_GetByID(t *testing.T) {
+	db := setupFranchiseTestDB(t)
+	repo := NewFranchiseIntentionRepository(db)
+
+	// 创建测试数据
+	testIntention := createTestFranchiseIntention(t, db, "member-123")
+
+	// 测试正确的ID
+	intention, err := repo.GetByID(testIntention.ID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if intention.ID != testIntention.ID {
+		t.Errorf("expected ID '%s', got '%s'", testIntention.ID, intention.ID)
+	}
+
+	if intention.ContactName != testIntention.ContactName {
+		t.Errorf("expected contact name '%s', got '%s'", testIntention.ContactName, intention.ContactName)
+	}
+
+	// 测试不存在的ID
+	_, err = repo.GetByID("non-existent-id")
+	if err == nil {
+		t.Error("expected error for non-existent intention")
+	}
+}
+
+func TestFranchiseIntentionRepository_GetByMemberID(t *testing.T) {
+	db := setupFranchiseTestDB(t)
+	repo := NewFranchiseIntentionRepository(db)
+
+	memberID := "member-456"
+
+	// 创建多个测试数据
+	createTestFranchiseIntention(t, db, memberID)
+
+	intention2 := &models.FranchiseIntention{
+		ID:               "test-franchise-2",
+		MemberID:         memberID,
+		ContactName:      "王五",
+		ContactPhone:     "13700137000",
+		IntendedLocation: "深圳市",
+		Status:           "Approved",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+	err := repo.Create(intention2)
+	if err != nil {
+		t.Fatalf("failed to create second intention: %v", err)
+	}
+
+	// 测试获取会员的意向列表
+	intentions, err := repo.GetByMemberID(memberID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(intentions) != 2 {
+		t.Errorf("expected 2 intentions, got %d", len(intentions))
+	}
+
+	// 测试不存在的会员ID
+	intentions, err = repo.GetByMemberID("non-existent-member")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(intentions) != 0 {
+		t.Errorf("expected 0 intentions, got %d", len(intentions))
+	}
+}
+
+func TestFranchiseIntentionRepository_CheckExistingByMember(t *testing.T) {
+	db := setupFranchiseTestDB(t)
+	repo := NewFranchiseIntentionRepository(db)
+
+	memberID := "member-789"
+
+	// 测试没有待处理意向的情况
+	exists, err := repo.CheckExistingByMember(memberID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if exists {
+		t.Error("expected no existing intention")
+	}
+
+	// 创建待处理意向
+	createTestFranchiseIntention(t, db, memberID)
+
+	// 测试有待处理意向的情况
+	exists, err = repo.CheckExistingByMember(memberID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !exists {
+		t.Error("expected existing intention")
+	}
+}
+
+func TestFranchiseIntentionRepository_UpdateStatus(t *testing.T) {
+	db := setupFranchiseTestDB(t)
+	repo := NewFranchiseIntentionRepository(db)
+
+	// 创建测试数据
+	testIntention := createTestFranchiseIntention(t, db, "member-999")
+
+	// 更新状态
+	err := repo.UpdateStatus(testIntention.ID, "Approved")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// 验证更新
+	intention, err := repo.GetByID(testIntention.ID)
+	if err != nil {
+		t.Fatalf("expected no error when getting updated intention, got %v", err)
+	}
+
+	if intention.Status != "Approved" {
+		t.Errorf("expected status 'Approved', got '%s'", intention.Status)
+	}
+}
+
+func TestFranchiseIntentionRepository_Update(t *testing.T) {
+	db := setupFranchiseTestDB(t)
+	repo := NewFranchiseIntentionRepository(db)
+
+	// 创建测试数据
+	testIntention := createTestFranchiseIntention(t, db, "member-111")
+
+	// 更新数据
+	testIntention.ContactName = "更新的姓名"
+	testIntention.ContactPhone = "13600136000"
+
+	err := repo.Update(testIntention)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// 验证更新
+	intention, err := repo.GetByID(testIntention.ID)
+	if err != nil {
+		t.Fatalf("expected no error when getting updated intention, got %v", err)
+	}
+
+	if intention.ContactName != "更新的姓名" {
+		t.Errorf("expected contact name '更新的姓名', got '%s'", intention.ContactName)
+	}
+}
+
+func TestFranchiseIntentionRepository_Delete(t *testing.T) {
+	db := setupFranchiseTestDB(t)
+	repo := NewFranchiseIntentionRepository(db)
+
+	// 创建测试数据
+	testIntention := createTestFranchiseIntention(t, db, "member-222")
+
+	// 删除数据
+	err := repo.Delete(testIntention.ID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// 验证删除
+	_, err = repo.GetByID(testIntention.ID)
+	if err == nil {
+		t.Error("expected error when getting deleted intention")
+	}
+}

--- a/internal/repositories/member_repository.go
+++ b/internal/repositories/member_repository.go
@@ -1,0 +1,95 @@
+package repositories
+
+import (
+	"fmt"
+
+	"github.com/ddteam/drink-master/internal/models"
+	"gorm.io/gorm"
+)
+
+// MemberRepository 会员数据访问层
+type MemberRepository struct {
+	db *gorm.DB
+}
+
+// NewMemberRepository 创建会员Repository实例
+func NewMemberRepository(db *gorm.DB) *MemberRepository {
+	return &MemberRepository{db: db}
+}
+
+// GetByID 根据ID获取会员信息
+func (r *MemberRepository) GetByID(id string) (*models.Member, error) {
+	var member models.Member
+	err := r.db.Where("id = ? AND deleted_at IS NULL", id).First(&member).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("member not found: %s", id)
+		}
+		return nil, fmt.Errorf("failed to get member: %w", err)
+	}
+	return &member, nil
+}
+
+// GetByWeChatOpenID 根据微信OpenID获取会员信息
+func (r *MemberRepository) GetByWeChatOpenID(openID string) (*models.Member, error) {
+	var member models.Member
+	err := r.db.Where("we_chat_open_id = ? AND deleted_at IS NULL", openID).First(&member).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("member not found with openID: %s", openID)
+		}
+		return nil, fmt.Errorf("failed to get member by openID: %w", err)
+	}
+	return &member, nil
+}
+
+// Update 更新会员信息
+func (r *MemberRepository) Update(member *models.Member) error {
+	err := r.db.Save(member).Error
+	if err != nil {
+		return fmt.Errorf("failed to update member: %w", err)
+	}
+	return nil
+}
+
+// Create 创建新会员
+func (r *MemberRepository) Create(member *models.Member) error {
+	err := r.db.Create(member).Error
+	if err != nil {
+		return fmt.Errorf("failed to create member: %w", err)
+	}
+	return nil
+}
+
+// Delete 软删除会员
+func (r *MemberRepository) Delete(id string) error {
+	err := r.db.Where("id = ?", id).Delete(&models.Member{}).Error
+	if err != nil {
+		return fmt.Errorf("failed to delete member: %w", err)
+	}
+	return nil
+}
+
+// GetMemberWithFranchiseIntentions 获取会员及其加盟意向
+func (r *MemberRepository) GetMemberWithFranchiseIntentions(
+	memberID string,
+) (*models.Member, []models.FranchiseIntention, error) {
+	var member models.Member
+	err := r.db.Where("id = ? AND deleted_at IS NULL", memberID).First(&member).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil, fmt.Errorf("member not found: %s", memberID)
+		}
+		return nil, nil, fmt.Errorf("failed to get member: %w", err)
+	}
+
+	var intentions []models.FranchiseIntention
+	err = r.db.Where("member_id = ? AND deleted_at IS NULL", memberID).
+		Order("created_at DESC").
+		Find(&intentions).Error
+	if err != nil {
+		return &member, nil, fmt.Errorf("failed to get franchise intentions: %w", err)
+	}
+
+	return &member, intentions, nil
+}

--- a/internal/repositories/member_repository_test.go
+++ b/internal/repositories/member_repository_test.go
@@ -1,0 +1,212 @@
+package repositories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ddteam/drink-master/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	// 迁移数据库
+	err = models.AutoMigrate(db)
+	if err != nil {
+		t.Fatalf("failed to migrate database: %v", err)
+	}
+
+	return db
+}
+
+func createTestMember(t *testing.T, db *gorm.DB) *models.Member {
+	member := &models.Member{
+		ID:           "test-member-1",
+		Nickname:     "测试用户",
+		Avatar:       "https://example.com/avatar.jpg",
+		WeChatOpenId: "test-openid-1",
+		Role:         "Member",
+		IsAdmin:      false,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	err := db.Create(member).Error
+	if err != nil {
+		t.Fatalf("failed to create test member: %v", err)
+	}
+
+	return member
+}
+
+func TestNewMemberRepository(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewMemberRepository(db)
+
+	if repo == nil {
+		t.Fatal("expected repository to be created")
+	}
+
+	if repo.db != db {
+		t.Error("expected repository to have correct database connection")
+	}
+}
+
+func TestMemberRepository_GetByID(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewMemberRepository(db)
+
+	// 创建测试数据
+	testMember := createTestMember(t, db)
+
+	// 测试正确的ID
+	member, err := repo.GetByID(testMember.ID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if member.ID != testMember.ID {
+		t.Errorf("expected member ID '%s', got '%s'", testMember.ID, member.ID)
+	}
+
+	if member.Nickname != testMember.Nickname {
+		t.Errorf("expected nickname '%s', got '%s'", testMember.Nickname, member.Nickname)
+	}
+
+	// 测试不存在的ID
+	_, err = repo.GetByID("non-existent-id")
+	if err == nil {
+		t.Error("expected error for non-existent member")
+	}
+}
+
+func TestMemberRepository_GetByWeChatOpenID(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewMemberRepository(db)
+
+	// 创建测试数据
+	testMember := createTestMember(t, db)
+
+	// 测试正确的OpenID
+	member, err := repo.GetByWeChatOpenID(testMember.WeChatOpenId)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if member.WeChatOpenId != testMember.WeChatOpenId {
+		t.Errorf("expected openID '%s', got '%s'", testMember.WeChatOpenId, member.WeChatOpenId)
+	}
+
+	// 测试不存在的OpenID
+	_, err = repo.GetByWeChatOpenID("non-existent-openid")
+	if err == nil {
+		t.Error("expected error for non-existent member")
+	}
+}
+
+func TestMemberRepository_Update(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewMemberRepository(db)
+
+	// 创建测试数据
+	testMember := createTestMember(t, db)
+
+	// 更新数据
+	testMember.Nickname = "更新的昵称"
+	testMember.Avatar = "https://example.com/new-avatar.jpg"
+
+	err := repo.Update(testMember)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// 验证更新
+	updatedMember, err := repo.GetByID(testMember.ID)
+	if err != nil {
+		t.Fatalf("expected no error when getting updated member, got %v", err)
+	}
+
+	if updatedMember.Nickname != "更新的昵称" {
+		t.Errorf("expected updated nickname '更新的昵称', got '%s'", updatedMember.Nickname)
+	}
+}
+
+func TestMemberRepository_Create(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewMemberRepository(db)
+
+	member := &models.Member{
+		ID:           "new-member-1",
+		Nickname:     "新用户",
+		Avatar:       "https://example.com/avatar.jpg",
+		WeChatOpenId: "new-openid-1",
+		Role:         "Member",
+		IsAdmin:      false,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	err := repo.Create(member)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// 验证创建
+	createdMember, err := repo.GetByID(member.ID)
+	if err != nil {
+		t.Fatalf("expected no error when getting created member, got %v", err)
+	}
+
+	if createdMember.Nickname != member.Nickname {
+		t.Errorf("expected nickname '%s', got '%s'", member.Nickname, createdMember.Nickname)
+	}
+}
+
+func TestMemberRepository_GetMemberWithFranchiseIntentions(t *testing.T) {
+	db := setupTestDB(t)
+	memberRepo := NewMemberRepository(db)
+	franchiseRepo := NewFranchiseIntentionRepository(db)
+
+	// 创建测试会员
+	testMember := createTestMember(t, db)
+
+	// 创建加盟意向
+	intention := &models.FranchiseIntention{
+		ID:               "test-intention-1",
+		MemberID:         testMember.ID,
+		ContactName:      "张三",
+		ContactPhone:     "13800138000",
+		IntendedLocation: "北京市",
+		Status:           "Pending",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	err := franchiseRepo.Create(intention)
+	if err != nil {
+		t.Fatalf("failed to create test franchise intention: %v", err)
+	}
+
+	// 测试获取会员和加盟意向
+	member, intentions, err := memberRepo.GetMemberWithFranchiseIntentions(testMember.ID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if member.ID != testMember.ID {
+		t.Errorf("expected member ID '%s', got '%s'", testMember.ID, member.ID)
+	}
+
+	if len(intentions) != 1 {
+		t.Errorf("expected 1 franchise intention, got %d", len(intentions))
+	}
+
+	if intentions[0].ID != intention.ID {
+		t.Errorf("expected intention ID '%s', got '%s'", intention.ID, intentions[0].ID)
+	}
+}

--- a/internal/repositories/member_repository_test.go
+++ b/internal/repositories/member_repository_test.go
@@ -210,3 +210,23 @@ func TestMemberRepository_GetMemberWithFranchiseIntentions(t *testing.T) {
 		t.Errorf("expected intention ID '%s', got '%s'", intention.ID, intentions[0].ID)
 	}
 }
+
+func TestMemberRepository_Delete(t *testing.T) {
+	db := setupTestDB(t)
+	memberRepo := NewMemberRepository(db)
+
+	// 创建测试会员
+	testMember := createTestMember(t, db)
+
+	// 删除会员
+	err := memberRepo.Delete(testMember.ID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// 验证删除
+	_, err = memberRepo.GetByID(testMember.ID)
+	if err == nil {
+		t.Error("expected error when getting deleted member")
+	}
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -41,6 +41,7 @@ func SetupRoutes(db *gorm.DB) *gin.Engine {
 	{
 		member.POST("/Update", memberHandler.Update)
 		member.POST("/AddFranchiseIntention", memberHandler.AddFranchiseIntention)
+		member.GET("/GetUserInfo", memberHandler.GetUserInfo)
 	}
 
 	// 基于MachineController的路由

--- a/internal/services/member_service.go
+++ b/internal/services/member_service.go
@@ -1,0 +1,220 @@
+package services
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ddteam/drink-master/internal/contracts"
+	"github.com/ddteam/drink-master/internal/models"
+	"github.com/ddteam/drink-master/internal/repositories"
+)
+
+// MemberService 会员业务逻辑层
+type MemberService struct {
+	memberRepo             *repositories.MemberRepository
+	franchiseIntentionRepo *repositories.FranchiseIntentionRepository
+}
+
+// NewMemberService 创建会员Service实例
+func NewMemberService(
+	memberRepo *repositories.MemberRepository,
+	franchiseIntentionRepo *repositories.FranchiseIntentionRepository,
+) *MemberService {
+	return &MemberService{
+		memberRepo:             memberRepo,
+		franchiseIntentionRepo: franchiseIntentionRepo,
+	}
+}
+
+// UpdateMember 更新会员信息
+func (s *MemberService) UpdateMember(
+	memberID string,
+	req contracts.UpdateMemberRequest,
+) (*contracts.UpdateMemberResponse, error) {
+	// 获取现有会员信息
+	member, err := s.memberRepo.GetByID(memberID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get member: %w", err)
+	}
+
+	// 验证输入数据
+	if req.Nickname == "" {
+		return nil, fmt.Errorf("nickname cannot be empty")
+	}
+	if req.Avatar == "" {
+		return nil, fmt.Errorf("avatar cannot be empty")
+	}
+
+	// 更新会员信息
+	member.Nickname = req.Nickname
+	member.Avatar = req.Avatar
+	member.UpdatedAt = time.Now()
+
+	err = s.memberRepo.Update(member)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update member: %w", err)
+	}
+
+	// 返回更新结果
+	response := &contracts.UpdateMemberResponse{
+		ID:       member.ID,
+		Nickname: member.Nickname,
+		Avatar:   member.Avatar,
+		Success:  true,
+	}
+
+	return response, nil
+}
+
+// CreateFranchiseIntention 创建加盟意向
+func (s *MemberService) CreateFranchiseIntention(
+	memberID string,
+	req contracts.CreateFranchiseIntentionRequest,
+) (*contracts.CreateFranchiseIntentionResponse, error) {
+	// 验证会员是否存在
+	_, err := s.memberRepo.GetByID(memberID)
+	if err != nil {
+		return nil, fmt.Errorf("member not found: %w", err)
+	}
+
+	// 检查是否已有待处理的加盟意向
+	hasExisting, err := s.franchiseIntentionRepo.CheckExistingByMember(memberID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing franchise intention: %w", err)
+	}
+	if hasExisting {
+		return nil, fmt.Errorf("member already has pending franchise intention")
+	}
+
+	// 验证输入数据
+	if req.ContactName == "" {
+		return nil, fmt.Errorf("contact name cannot be empty")
+	}
+	if req.ContactPhone == "" {
+		return nil, fmt.Errorf("contact phone cannot be empty")
+	}
+	if req.IntendedLocation == "" {
+		return nil, fmt.Errorf("intended location cannot be empty")
+	}
+
+	// 创建加盟意向
+	intention := &models.FranchiseIntention{
+		ID:               s.generateFranchiseIntentionID(),
+		MemberID:         memberID,
+		ContactName:      req.ContactName,
+		ContactPhone:     req.ContactPhone,
+		IntendedLocation: req.IntendedLocation,
+		Remarks:          req.Remarks,
+		Status:           "Pending",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	err = s.franchiseIntentionRepo.Create(intention)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create franchise intention: %w", err)
+	}
+
+	// 返回创建结果
+	response := &contracts.CreateFranchiseIntentionResponse{
+		ID:               intention.ID,
+		MemberID:         intention.MemberID,
+		ContactName:      intention.ContactName,
+		ContactPhone:     intention.ContactPhone,
+		IntendedLocation: intention.IntendedLocation,
+		Status:           intention.Status,
+		CreatedAt:        intention.CreatedAt,
+		Success:          true,
+	}
+
+	return response, nil
+}
+
+// GetMemberInfo 获取会员详细信息
+func (s *MemberService) GetMemberInfo(memberID string) (*contracts.GetMemberInfoResponse, error) {
+	// 获取会员信息和加盟意向
+	member, intentions, err := s.memberRepo.GetMemberWithFranchiseIntentions(memberID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get member info: %w", err)
+	}
+
+	// 转换加盟意向为摘要格式
+	var intentionSummaries []contracts.FranchiseIntentionSummary
+	for _, intention := range intentions {
+		summary := contracts.FranchiseIntentionSummary{
+			ID:               intention.ID,
+			ContactName:      intention.ContactName,
+			IntendedLocation: intention.IntendedLocation,
+			Status:           contracts.FranchiseIntentionStatus(intention.Status),
+			CreatedAt:        intention.CreatedAt,
+		}
+		intentionSummaries = append(intentionSummaries, summary)
+	}
+
+	// 构建响应
+	response := &contracts.GetMemberInfoResponse{
+		ID:                  member.ID,
+		Nickname:            member.Nickname,
+		Avatar:              member.Avatar,
+		WeChatOpenID:        member.WeChatOpenId,
+		Role:                member.Role,
+		IsAdmin:             member.IsAdmin,
+		CreatedAt:           member.CreatedAt,
+		UpdatedAt:           member.UpdatedAt,
+		FranchiseIntentions: intentionSummaries,
+	}
+
+	// 设置机主ID（如果存在）
+	if member.MachineOwnerId != nil {
+		response.MachineOwnerID = *member.MachineOwnerId
+	}
+
+	return response, nil
+}
+
+// ValidateMemberExists 验证会员是否存在
+func (s *MemberService) ValidateMemberExists(memberID string) error {
+	_, err := s.memberRepo.GetByID(memberID)
+	if err != nil {
+		return fmt.Errorf("member validation failed: %w", err)
+	}
+	return nil
+}
+
+// UpdateFranchiseIntentionStatus 更新加盟意向状态（管理员功能）
+func (s *MemberService) UpdateFranchiseIntentionStatus(intentionID string, status string) error {
+	// 验证状态值
+	validStatuses := []string{"Pending", "Approved", "Rejected"}
+	statusValid := false
+	for _, validStatus := range validStatuses {
+		if status == validStatus {
+			statusValid = true
+			break
+		}
+	}
+	if !statusValid {
+		return fmt.Errorf("invalid status: %s", status)
+	}
+
+	// 更新状态
+	err := s.franchiseIntentionRepo.UpdateStatus(intentionID, status)
+	if err != nil {
+		return fmt.Errorf("failed to update franchise intention status: %w", err)
+	}
+
+	return nil
+}
+
+// generateFranchiseIntentionID 生成加盟意向ID
+func (s *MemberService) generateFranchiseIntentionID() string {
+	// 生成8位随机字符串
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, 8)
+	for i := range b {
+		num, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		b[i] = charset[num.Int64()]
+	}
+	return "fi-" + string(b)
+}

--- a/internal/services/member_service_test.go
+++ b/internal/services/member_service_test.go
@@ -1,0 +1,310 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ddteam/drink-master/internal/contracts"
+	"github.com/ddteam/drink-master/internal/models"
+	"github.com/ddteam/drink-master/internal/repositories"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupServiceTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	err = models.AutoMigrate(db)
+	if err != nil {
+		t.Fatalf("failed to migrate database: %v", err)
+	}
+
+	return db
+}
+
+func createServiceTestMember(t *testing.T, db *gorm.DB) *models.Member {
+	member := &models.Member{
+		ID:           "service-test-member-1",
+		Nickname:     "服务测试用户",
+		Avatar:       "https://example.com/old-avatar.jpg",
+		WeChatOpenId: "service-test-openid-1",
+		Role:         "Member",
+		IsAdmin:      false,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	err := db.Create(member).Error
+	if err != nil {
+		t.Fatalf("failed to create test member: %v", err)
+	}
+
+	return member
+}
+
+func TestNewMemberService(t *testing.T) {
+	db := setupServiceTestDB(t)
+	memberRepo := repositories.NewMemberRepository(db)
+	franchiseRepo := repositories.NewFranchiseIntentionRepository(db)
+
+	service := NewMemberService(memberRepo, franchiseRepo)
+
+	if service == nil {
+		t.Fatal("expected service to be created")
+	}
+
+	if service.memberRepo != memberRepo {
+		t.Error("expected service to have correct member repository")
+	}
+
+	if service.franchiseIntentionRepo != franchiseRepo {
+		t.Error("expected service to have correct franchise repository")
+	}
+}
+
+func TestMemberService_UpdateMember(t *testing.T) {
+	db := setupServiceTestDB(t)
+	memberRepo := repositories.NewMemberRepository(db)
+	franchiseRepo := repositories.NewFranchiseIntentionRepository(db)
+	service := NewMemberService(memberRepo, franchiseRepo)
+
+	// 创建测试数据
+	testMember := createServiceTestMember(t, db)
+
+	// 测试正常更新
+	req := contracts.UpdateMemberRequest{
+		Nickname: "新昵称",
+		Avatar:   "https://example.com/new-avatar.jpg",
+	}
+
+	response, err := service.UpdateMember(testMember.ID, req)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+
+	if response.Nickname != req.Nickname {
+		t.Errorf("expected nickname '%s', got '%s'", req.Nickname, response.Nickname)
+	}
+
+	if response.Avatar != req.Avatar {
+		t.Errorf("expected avatar '%s', got '%s'", req.Avatar, response.Avatar)
+	}
+
+	// 测试空昵称
+	emptyReq := contracts.UpdateMemberRequest{
+		Nickname: "",
+		Avatar:   "https://example.com/avatar.jpg",
+	}
+
+	_, err = service.UpdateMember(testMember.ID, emptyReq)
+	if err == nil {
+		t.Error("expected error for empty nickname")
+	}
+
+	// 测试不存在的用户
+	_, err = service.UpdateMember("non-existent-id", req)
+	if err == nil {
+		t.Error("expected error for non-existent member")
+	}
+}
+
+func TestMemberService_CreateFranchiseIntention(t *testing.T) {
+	db := setupServiceTestDB(t)
+	memberRepo := repositories.NewMemberRepository(db)
+	franchiseRepo := repositories.NewFranchiseIntentionRepository(db)
+	service := NewMemberService(memberRepo, franchiseRepo)
+
+	// 创建测试数据
+	testMember := createServiceTestMember(t, db)
+
+	// 测试正常创建
+	req := contracts.CreateFranchiseIntentionRequest{
+		ContactName:      "张三",
+		ContactPhone:     "13800138000",
+		IntendedLocation: "北京市朝阳区",
+		Remarks:          "希望在繁华地段开店",
+	}
+
+	response, err := service.CreateFranchiseIntention(testMember.ID, req)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+
+	if response.ContactName != req.ContactName {
+		t.Errorf("expected contact name '%s', got '%s'", req.ContactName, response.ContactName)
+	}
+
+	if response.Status != "Pending" {
+		t.Errorf("expected status 'Pending', got '%s'", response.Status)
+	}
+
+	// 测试重复创建（应该失败）
+	_, err = service.CreateFranchiseIntention(testMember.ID, req)
+	if err == nil {
+		t.Error("expected error for duplicate franchise intention")
+	}
+
+	// 测试空联系人姓名
+	emptyReq := contracts.CreateFranchiseIntentionRequest{
+		ContactName:      "",
+		ContactPhone:     "13800138000",
+		IntendedLocation: "北京市朝阳区",
+	}
+
+	_, err = service.CreateFranchiseIntention("another-member-id", emptyReq)
+	if err == nil {
+		t.Error("expected error for empty contact name")
+	}
+}
+
+func TestMemberService_GetMemberInfo(t *testing.T) {
+	db := setupServiceTestDB(t)
+	memberRepo := repositories.NewMemberRepository(db)
+	franchiseRepo := repositories.NewFranchiseIntentionRepository(db)
+	service := NewMemberService(memberRepo, franchiseRepo)
+
+	// 创建测试数据
+	testMember := createServiceTestMember(t, db)
+
+	// 创建加盟意向
+	intention := &models.FranchiseIntention{
+		ID:               "service-test-intention-1",
+		MemberID:         testMember.ID,
+		ContactName:      "李四",
+		ContactPhone:     "13900139000",
+		IntendedLocation: "上海市",
+		Status:           "Pending",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	err := franchiseRepo.Create(intention)
+	if err != nil {
+		t.Fatalf("failed to create test intention: %v", err)
+	}
+
+	// 测试获取会员信息
+	response, err := service.GetMemberInfo(testMember.ID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if response.ID != testMember.ID {
+		t.Errorf("expected ID '%s', got '%s'", testMember.ID, response.ID)
+	}
+
+	if response.Nickname != testMember.Nickname {
+		t.Errorf("expected nickname '%s', got '%s'", testMember.Nickname, response.Nickname)
+	}
+
+	if len(response.FranchiseIntentions) != 1 {
+		t.Errorf("expected 1 franchise intention, got %d", len(response.FranchiseIntentions))
+	}
+
+	if response.FranchiseIntentions[0].ContactName != intention.ContactName {
+		t.Errorf("expected contact name '%s', got '%s'", intention.ContactName, response.FranchiseIntentions[0].ContactName)
+	}
+
+	// 测试不存在的用户
+	_, err = service.GetMemberInfo("non-existent-id")
+	if err == nil {
+		t.Error("expected error for non-existent member")
+	}
+}
+
+func TestMemberService_ValidateMemberExists(t *testing.T) {
+	db := setupServiceTestDB(t)
+	memberRepo := repositories.NewMemberRepository(db)
+	franchiseRepo := repositories.NewFranchiseIntentionRepository(db)
+	service := NewMemberService(memberRepo, franchiseRepo)
+
+	// 创建测试数据
+	testMember := createServiceTestMember(t, db)
+
+	// 测试存在的用户
+	err := service.ValidateMemberExists(testMember.ID)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	// 测试不存在的用户
+	err = service.ValidateMemberExists("non-existent-id")
+	if err == nil {
+		t.Error("expected error for non-existent member")
+	}
+}
+
+func TestMemberService_UpdateFranchiseIntentionStatus(t *testing.T) {
+	db := setupServiceTestDB(t)
+	memberRepo := repositories.NewMemberRepository(db)
+	franchiseRepo := repositories.NewFranchiseIntentionRepository(db)
+	service := NewMemberService(memberRepo, franchiseRepo)
+
+	// 创建测试数据
+	testMember := createServiceTestMember(t, db)
+	intention := &models.FranchiseIntention{
+		ID:               "test-status-intention-1",
+		MemberID:         testMember.ID,
+		ContactName:      "王五",
+		ContactPhone:     "13700137000",
+		IntendedLocation: "深圳市",
+		Status:           "Pending",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	err := franchiseRepo.Create(intention)
+	if err != nil {
+		t.Fatalf("failed to create test intention: %v", err)
+	}
+
+	// 测试有效状态更新
+	err = service.UpdateFranchiseIntentionStatus(intention.ID, "Approved")
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	// 测试无效状态
+	err = service.UpdateFranchiseIntentionStatus(intention.ID, "InvalidStatus")
+	if err == nil {
+		t.Error("expected error for invalid status")
+	}
+}
+
+func TestMemberService_generateFranchiseIntentionID(t *testing.T) {
+	db := setupServiceTestDB(t)
+	memberRepo := repositories.NewMemberRepository(db)
+	franchiseRepo := repositories.NewFranchiseIntentionRepository(db)
+	service := NewMemberService(memberRepo, franchiseRepo)
+
+	id := service.generateFranchiseIntentionID()
+
+	if id == "" {
+		t.Error("expected non-empty ID")
+	}
+
+	if len(id) != 11 { // "fi-" + 8 characters
+		t.Errorf("expected ID length 11, got %d", len(id))
+	}
+
+	if id[:3] != "fi-" {
+		t.Errorf("expected ID to start with 'fi-', got '%s'", id[:3])
+	}
+
+	// 测试生成的ID是唯一的
+	id2 := service.generateFranchiseIntentionID()
+	if id == id2 {
+		t.Error("expected different IDs to be generated")
+	}
+}


### PR DESCRIPTION
## Summary
- 🔧 **Member API接口**: Update, AddFranchiseIntention, GetUserInfo  
- 🗄️ **完整数据层**: MemberRepository, FranchiseIntentionRepository
- 🎯 **业务逻辑层**: MemberService 核心业务实现
- 📊 **数据模型**: FranchiseIntention 加盟意向管理

## 主要变更
### 新增组件
- `internal/contracts/member.go` - Member接口契约定义
- `internal/models/franchise_intention.go` - 加盟意向数据模型
- `internal/services/member_service.go` - 会员业务逻辑服务
- `internal/repositories/member_repository.go` - 会员数据访问层
- `internal/repositories/franchise_intention_repository.go` - 加盟意向数据访问

### API接口实现
```
POST /api/Member/Update              - 更新会员信息(昵称、头像)
POST /api/Member/AddFranchiseIntention - 提交加盟意向
GET  /api/Member/GetUserInfo         - 获取会员详细信息
```

### 核心功能特性
- **权限控制**: JWT认证，只能操作自己的数据
- **业务验证**: 防重复提交加盟意向，输入完整性校验
- **数据安全**: 会员ID从JWT token获取，不依赖请求参数
- **状态管理**: 加盟意向支持Pending/Approved/Rejected状态

## 技术实现
- **数据层设计**: 使用GORM，支持软删除和关联查询
- **错误处理**: 统一错误码定义，区分业务异常和系统异常
- **测试覆盖**: Repository和Service层完整单元测试
- **API规范**: 严格按照MobileAPI MemberController规范

## Test plan
- [x] Member Contract单元测试 (请求/响应验证)
- [x] MemberRepository数据层测试 (CRUD + 关联查询)
- [x] MemberService业务逻辑测试 (业务规则验证) 
- [x] 会员信息更新功能测试
- [x] 加盟意向创建和重复检查测试
- [x] 权限控制和错误处理测试

## 验收标准 ✅
- [x] 实现MemberController所有3个核心接口
- [x] 支持会员信息更新功能 (昵称、头像)
- [x] 加盟意向创建和状态管理
- [x] 权限控制: 只能更新自己的信息
- [x] 完善的错误处理和响应格式
- [x] 响应格式与MobileAPI规范一致
- [x] 核心业务逻辑单元测试覆盖

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)