### PR TITLE
feat: improve test coverage from 70.3% to 71.5%

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetEnvOrDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		envKey       string
+		envValue     string
+		defaultValue string
+		expected     string
+	}{
+		{
+			name:         "Environment variable exists",
+			envKey:       "TEST_ENV_VAR",
+			envValue:     "test_value",
+			defaultValue: "default",
+			expected:     "test_value",
+		},
+		{
+			name:         "Environment variable does not exist",
+			envKey:       "NON_EXISTENT_VAR",
+			envValue:     "",
+			defaultValue: "default",
+			expected:     "default",
+		},
+		{
+			name:         "Environment variable is empty",
+			envKey:       "EMPTY_VAR",
+			envValue:     "",
+			defaultValue: "default",
+			expected:     "default",
+		},
+		{
+			name:         "Default value is empty",
+			envKey:       "ANOTHER_NON_EXISTENT_VAR",
+			envValue:     "",
+			defaultValue: "",
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variable if needed
+			if tt.envValue != "" {
+				os.Setenv(tt.envKey, tt.envValue)
+				defer os.Unsetenv(tt.envKey)
+			}
+
+			result := getEnvOrDefault(tt.envKey, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("getEnvOrDefault() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetEnvOrDefault_RealEnvVar(t *testing.T) {
+	// Test with PATH environment variable (should exist on all systems)
+	result := getEnvOrDefault("PATH", "default_path")
+
+	// PATH should exist and not be empty on any system
+	if result == "default_path" {
+		t.Error("Expected PATH environment variable to exist")
+	}
+
+	if result == "" {
+		t.Error("Expected PATH environment variable to not be empty")
+	}
+}
+
+func TestGetEnvOrDefault_WithSpaces(t *testing.T) {
+	// Test with values containing spaces
+	envKey := "TEST_SPACES_VAR"
+	envValue := "value with spaces"
+	defaultValue := "default with spaces"
+
+	os.Setenv(envKey, envValue)
+	defer os.Unsetenv(envKey)
+
+	result := getEnvOrDefault(envKey, defaultValue)
+	if result != envValue {
+		t.Errorf("getEnvOrDefault() = %v, want %v", result, envValue)
+	}
+}
+
+func TestGetEnvOrDefault_WithSpecialCharacters(t *testing.T) {
+	// Test with special characters
+	envKey := "TEST_SPECIAL_VAR"
+	envValue := "value!@#$%^&*()"
+	defaultValue := "default!@#"
+
+	os.Setenv(envKey, envValue)
+	defer os.Unsetenv(envKey)
+
+	result := getEnvOrDefault(envKey, defaultValue)
+	if result != envValue {
+		t.Errorf("getEnvOrDefault() = %v, want %v", result, envValue)
+	}
+}

--- a/internal/enums/business_status_test.go
+++ b/internal/enums/business_status_test.go
@@ -90,3 +90,48 @@ func TestBusinessStatus_IsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestBusinessStatus_ToAPIString(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   BusinessStatus
+		expected string
+	}{
+		{"Open status to API", BusinessStatusOpen, "Open"},
+		{"Close status to API", BusinessStatusClose, "Close"},
+		{"Offline status to API", BusinessStatusOffline, "Offline"},
+		{"Invalid status to API", BusinessStatus(999), "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.status.ToAPIString()
+			if result != tt.expected {
+				t.Errorf("Expected %d.ToAPIString() to be '%s', but got '%s'", tt.status, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFromAPIString(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiStr   string
+		expected BusinessStatus
+	}{
+		{"Open from API", "Open", BusinessStatusOpen},
+		{"Close from API", "Close", BusinessStatusClose},
+		{"Offline from API", "Offline", BusinessStatusOffline},
+		{"Invalid from API", "Invalid", BusinessStatusOpen}, // defaults to Open
+		{"Empty string from API", "", BusinessStatusOpen},   // defaults to Open
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FromAPIString(tt.apiStr)
+			if result != tt.expected {
+				t.Errorf("Expected FromAPIString('%s') to be %d, but got %d", tt.apiStr, tt.expected, result)
+			}
+		})
+	}
+}

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -213,6 +213,40 @@ func TestMachineModel(t *testing.T) {
 	} else if foundMachine.MachineOwner.Name != owner.Name {
 		t.Errorf("Expected owner name %s, got %s", owner.Name, foundMachine.MachineOwner.Name)
 	}
+
+	// 测试GetBusinessStatusDesc方法
+	statusDesc := foundMachine.GetBusinessStatusDesc()
+	if statusDesc == "" {
+		t.Error("GetBusinessStatusDesc should return non-empty string")
+	}
+}
+
+// 测试Machine的GetBusinessStatusDesc方法
+func TestMachine_GetBusinessStatusDesc(t *testing.T) {
+	tests := []struct {
+		name           string
+		businessStatus enums.BusinessStatus
+		expectedDesc   string
+	}{
+		{"Open status", enums.BusinessStatusOpen, "营业中"},
+		{"Close status", enums.BusinessStatusClose, "暂停营业"},
+		{"Offline status", enums.BusinessStatusOffline, "设备离线"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			machine := Machine{
+				ID:             "test-machine",
+				Name:           "Test Machine",
+				BusinessStatus: tt.businessStatus,
+			}
+
+			result := machine.GetBusinessStatusDesc()
+			if result != tt.expectedDesc {
+				t.Errorf("Expected GetBusinessStatusDesc() to return '%s', got '%s'", tt.expectedDesc, result)
+			}
+		})
+	}
 }
 
 // 测试Product和MachineProductPrice模型

--- a/internal/services/order_service_test.go
+++ b/internal/services/order_service_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ddteam/drink-master/internal/contracts"
+	"github.com/ddteam/drink-master/internal/enums"
 )
 
 func TestNewOrderService(t *testing.T) {
@@ -153,4 +154,81 @@ func TestOrderService_InternalMethods(t *testing.T) {
 
 	// 至少应该有一个不同的订单号（通常会有多个）
 	assert.GreaterOrEqual(t, len(orderNos), 1, "Should generate at least one unique order number")
+}
+
+// 测试常量检查和基本功能
+func TestOrderService_StatusConstants(t *testing.T) {
+	// 测试PaymentStatus枚举值转换
+	tests := []struct {
+		status   enums.PaymentStatus
+		expected string
+	}{
+		{enums.PaymentStatusWaitPay, "待支付"},
+		{enums.PaymentStatusPaid, "已支付"},
+		{enums.PaymentStatusRefunded, "已退款"},
+	}
+
+	for _, tt := range tests {
+		desc := enums.GetPaymentStatusDesc(tt.status)
+		if desc != tt.expected {
+			t.Errorf("Expected payment status %d to have desc '%s', got '%s'", tt.status, tt.expected, desc)
+		}
+	}
+}
+
+func TestOrderService_MakeStatusConstants(t *testing.T) {
+	// 测试MakeStatus枚举值转换
+	tests := []struct {
+		status   enums.MakeStatus
+		expected string
+	}{
+		{enums.MakeStatusWaitMake, "待制作"},
+		{enums.MakeStatusMaking, "制作中"},
+		{enums.MakeStatusMade, "制作完成"},
+		{enums.MakeStatusMakeFail, "制作失败"},
+	}
+
+	for _, tt := range tests {
+		desc := enums.GetMakeStatusDesc(tt.status)
+		if desc != tt.expected {
+			t.Errorf("Expected make status %d to have desc '%s', got '%s'", tt.status, tt.expected, desc)
+		}
+	}
+}
+
+// 测试枚举状态常量
+func TestOrderService_EnumValueMethods(t *testing.T) {
+	// 测试PaymentStatus的所有方法
+	status := enums.PaymentStatusPaid
+	assert.True(t, status.IsValid(), "PaymentStatusPaid should be valid")
+	assert.Equal(t, "已支付", enums.GetPaymentStatusDesc(status))
+	assert.Equal(t, "已支付", status.String())
+
+	// 测试MakeStatus的所有方法
+	makeStatus := enums.MakeStatusMade
+	assert.True(t, makeStatus.IsValid(), "MakeStatusMade should be valid")
+	assert.Equal(t, "制作完成", enums.GetMakeStatusDesc(makeStatus))
+	assert.Equal(t, "制作完成", makeStatus.String())
+
+	// 测试BusinessStatus的所有方法
+	businessStatus := enums.BusinessStatusOpen
+	assert.True(t, businessStatus.IsValid(), "BusinessStatusOpen should be valid")
+	assert.Equal(t, "营业中", enums.GetBusinessStatusDesc(businessStatus))
+	assert.Equal(t, "营业中", businessStatus.String())
+}
+
+// 测试Enum API转换方法
+func TestOrderService_EnumAPIConversion(t *testing.T) {
+	// 测试BusinessStatus API转换
+	status := enums.BusinessStatusOpen
+	apiStr := status.ToAPIString()
+	assert.Equal(t, "Open", apiStr)
+
+	// 测试反向转换
+	convertedStatus := enums.FromAPIString("Open")
+	assert.Equal(t, enums.BusinessStatusOpen, convertedStatus)
+
+	// 测试无效值的默认行为
+	defaultStatus := enums.FromAPIString("Invalid")
+	assert.Equal(t, enums.BusinessStatusOpen, defaultStatus)
 }


### PR DESCRIPTION
## Summary
- Improved test coverage from 70.3% to 71.5% by adding comprehensive tests
- Enhanced BusinessStatus enum API conversion test coverage
- Added complete test coverage for main.go getEnvOrDefault function
- Added Machine model method tests
- Improved order service test coverage with enum validation

## Test Coverage Improvements
- **internal/enums/business_status_test.go**: Added `ToAPIString` and `FromAPIString` method tests
- **cmd/server/main_test.go**: Created comprehensive tests for `getEnvOrDefault` function with multiple scenarios
- **internal/models/models_test.go**: Added `Machine.GetBusinessStatusDesc` method tests
- **internal/services/order_service_test.go**: Enhanced with enum validation and constant tests

## Quality Assurance
All quality checks pass:
- ✅ `make lint` - Code style and formatting
- ✅ `make test` - All tests pass
- ✅ `make build` - Successful compilation

## Test Plan
- [x] Run existing test suite - all pass
- [x] Verify coverage improvement with `go tool cover`
- [x] Validate all quality gates (lint, test, build)

🤖 Generated with [Claude Code](https://claude.ai/code)