### PR TITLE
fix: standardize API route naming to match MobileAPI controller conventions

### DIFF
--- a/internal/handlers/machine_owner.go
+++ b/internal/handlers/machine_owner.go
@@ -26,7 +26,18 @@ func NewMachineOwnerHandler(db *gorm.DB) *MachineOwnerHandler {
 }
 
 // GetSales 获取销售情况
-// GET /api/machine-owners/sales?dateTime=2025-08-11
+// @Summary 获取机主销售情况
+// @Description 获取指定日期的机主销售数据，默认为当天
+// @Tags MachineOwner
+// @Accept json
+// @Produce json
+// @Param dateTime query string false "查询日期 (YYYY-MM-DD格式)"
+// @Success 200 {object} contracts.MachineOwnerSalesResponse
+// @Failure 401 {object} contracts.APIResponse
+// @Failure 403 {object} contracts.APIResponse
+// @Failure 500 {object} contracts.APIResponse
+// @Router /MachineOwner/GetSales [get]
+// @Security Bearer
 // 对应原方法: Task<List<ColumnModel>> GetSalesAsync([FromQuery] DateTime? dateTime)
 func (h *MachineOwnerHandler) GetSales(c *gin.Context) {
 	// 验证是否为机主
@@ -79,7 +90,20 @@ func (h *MachineOwnerHandler) GetSales(c *gin.Context) {
 }
 
 // GetSalesStats 获取销售统计 (扩展功能，可选实现)
-// GET /api/machine-owners/sales/stats?startDate=2025-08-01&endDate=2025-08-11
+// @Summary 获取机主销售统计
+// @Description 获取指定日期范围内的机主销售统计数据
+// @Tags MachineOwner
+// @Accept json
+// @Produce json
+// @Param startDate query string false "开始日期 (YYYY-MM-DD格式)，默认7天前"
+// @Param endDate query string false "结束日期 (YYYY-MM-DD格式)，默认今天"
+// @Success 200 {object} contracts.APIResponse
+// @Failure 400 {object} contracts.APIResponse
+// @Failure 401 {object} contracts.APIResponse
+// @Failure 403 {object} contracts.APIResponse
+// @Failure 500 {object} contracts.APIResponse
+// @Router /MachineOwner/GetSalesStats [get]
+// @Security Bearer
 func (h *MachineOwnerHandler) GetSalesStats(c *gin.Context) {
 	// 验证是否为机主
 	if !h.IsMachineOwner(c) {

--- a/internal/handlers/product.go
+++ b/internal/handlers/product.go
@@ -27,7 +27,7 @@ func NewProductHandler(db *gorm.DB) *ProductHandler {
 // @Produce json
 // @Success 200 {object} contracts.APIResponse{data=[]contracts.SelectViewModel}
 // @Failure 500 {object} contracts.APIResponse
-// @Router /products/select [get]
+// @Router /Product/GetSelectList [get]
 func (h *ProductHandler) GetSelectList(c *gin.Context) {
 	// Step 1: Get all products directly from products table using correct column mapping
 	var products []models.Product

--- a/internal/handlers/product_test.go
+++ b/internal/handlers/product_test.go
@@ -88,7 +88,7 @@ func TestProductHandler_GetSelectList(t *testing.T) {
 	// 创建请求
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	req, _ := http.NewRequest("GET", "/api/products/select", nil)
+	req, _ := http.NewRequest("GET", "/api/Product/GetSelectList", nil)
 	c.Request = req
 
 	// 执行测试
@@ -132,7 +132,7 @@ func TestProductHandler_GetSelectList_EmptyResult(t *testing.T) {
 	// 创建请求
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	req, _ := http.NewRequest("GET", "/api/products/select", nil)
+	req, _ := http.NewRequest("GET", "/api/Product/GetSelectList", nil)
 	c.Request = req
 
 	// 执行测试

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -104,10 +104,10 @@ func SetupRoutes(db *gorm.DB) *gin.Engine {
 
 	// 基于ProductController的路由
 	productHandler := handlers.NewProductHandler(db)
-	product := router.Group("/api/products")
+	product := router.Group("/api/Product")
 	{
 		// 公开接口
-		product.GET("/select", productHandler.GetSelectList)
+		product.GET("/GetSelectList", productHandler.GetSelectList)
 	}
 
 	// 基于MaterialSiloController的路由 (物料槽管理)
@@ -123,11 +123,11 @@ func SetupRoutes(db *gorm.DB) *gin.Engine {
 
 	// 基于MachineOwnerController的路由 (机主管理功能)
 	machineOwnerHandler := handlers.NewMachineOwnerHandler(db)
-	machineOwner := router.Group("/api/machine-owners")
+	machineOwner := router.Group("/api/MachineOwner")
 	machineOwner.Use(middleware.JWTAuth()) // 所有机主接口都需要认证
 	{
-		machineOwner.GET("/sales", machineOwnerHandler.GetSales)
-		machineOwner.GET("/sales/stats", machineOwnerHandler.GetSalesStats)
+		machineOwner.GET("/GetSales", machineOwnerHandler.GetSales)
+		machineOwner.GET("/GetSalesStats", machineOwnerHandler.GetSalesStats)
 	}
 
 	// 基于CallbackController的路由 (无需认证)


### PR DESCRIPTION
## Summary
- ✅ Update Product route from `/api/products/select` to `/api/Product/GetSelectList`
- ✅ Update MachineOwner route group from `/api/machine-owners` to `/api/MachineOwner`
- ✅ Update sales routes from `/sales` to `/GetSales` and `/sales/stats` to `/GetSalesStats`
- ✅ Update corresponding unit tests to match new route paths

## Changes Made
1. **Product routes** (`internal/routes/routes.go:107-111`):
   - Changed route group from `/api/products` to `/api/Product`
   - Changed endpoint from `/select` to `/GetSelectList`

2. **MachineOwner routes** (`internal/routes/routes.go:126-131`):
   - Changed route group from `/api/machine-owners` to `/api/MachineOwner`
   - Changed endpoint from `/sales` to `/GetSales`
   - Changed endpoint from `/sales/stats` to `/GetSalesStats`

3. **Unit tests** (`internal/handlers/product_test.go`):
   - Updated test requests to use new route `/api/Product/GetSelectList`

## Test Results
- ✅ Route tests pass: `TestSetupRoutes`
- ✅ Product handler tests pass: `TestProductHandler_GetSelectList`
- ✅ Lint checks pass

## Breaking Changes
⚠️ This is a breaking change for API consumers. The following routes have changed:
- `GET /api/products/select` → `GET /api/Product/GetSelectList`
- `GET /api/machine-owners/sales` → `GET /api/MachineOwner/GetSales`
- `GET /api/machine-owners/sales/stats` → `GET /api/MachineOwner/GetSalesStats`

Fixes #61

🤖 Generated with [Claude Code](https://claude.ai/code)